### PR TITLE
UI Admin Log: Show User IP Address for Who  Make UI Actions

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -243,6 +243,8 @@ def action_logging(f):
     def wrapper(*args, **kwargs):
         if current_user and hasattr(current_user, 'username'):
             user = current_user.username
+        elif request.remote_addr is not None:
+            user = request.remote_addr
         else:
             user = 'anonymous'
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
